### PR TITLE
Use Github Actions for CI

### DIFF
--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -1,4 +1,4 @@
-name: Build pre-release
+name: Build artifact from latest code changes
 
 on:
   push:

--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -16,10 +16,10 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     - name: Build artifact from source
-      run: msbuild "${env:GITHUB_WORKSPACE}\VATCANSitu.vcxproj" /p:AssemblyName=VATCANSitu-nightly
+      run: msbuild "${env:GITHUB_WORKSPACE}\VATCANSitu.vcxproj"
 
-    - name: Create release
-      uses: ncipollo/release-action@v1
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
       with:
-        artifacts: "VATCANSitu-nightly.dll"
-        prerelease: true
+        name: Plugin DLL
+        path: Debug\VATCANSitu.dll

--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -1,0 +1,25 @@
+name: Build pre-release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: windows-2019
+    steps:
+    - name: Checkout vatcansitu
+      uses: actions/checkout@v3
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Build artifact from source
+      run: msbuild "${env:GITHUB_WORKSPACE}\VATCANSitu.vcxproj" /p:AssemblyName=VATCANSitu-nightly
+
+    - name: Create release
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "VATCANSitu-nightly.dll"
+        prerelease: true


### PR DESCRIPTION
AppVeyor allows artifacts to persist for 30 days, Actions allows a 90-day grace period.

If needed, this action can be amended to use Github's pre-release system which should allow artifacts to persist forever (although, I don't believe this is required).